### PR TITLE
Changed spec/.jshintrc "expr" to true.

### DIFF
--- a/linting/JavaScript/specs/.jshintrc
+++ b/linting/JavaScript/specs/.jshintrc
@@ -44,7 +44,7 @@
 	"es5": false, //your code uses ECMAScript 5 specific features such as getters and setters
 	"esnext": false, //your code uses ES.next specific features such as const
 	"evil": false, //suppresses warnings about the use of eval
-	"expr": false, //suppresses warnings about the use of expressions where normally you would expect to see assignments or function calls
+	"expr": true, //suppresses warnings about the use of expressions where normally you would expect to see assignments or function calls
 	"funcscope": false, //suppresses warnings about declaring variables inside of control structures while accessing them later from the outside
 	"globalstrict": false, //suppresses warnings about the use of global strict mode
 	"iterator": false, //suppresses warnings about the `__iterator__` property


### PR DESCRIPTION
This tells JSHint stop giving this warning

`Expected an assignment or function call and instead saw an expression.`

for statements like this:

``` js
something.should.be.ok;

err.should.be.an.Error;
```

Especially helpful when using should.js

http://www.jshint.com/docs/options/#expr
